### PR TITLE
Checks if stack trace exists when logging errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,9 +84,11 @@ parser.on('fail', assert => {
 
   console.log()
 
-  e.stack.split('\n').forEach(line => {
-    console.log(' ', chalk.gray(line))
-  })
+  if (e.stack !== undefined) {
+    e.stack.split('\n').forEach(line => {
+      console.log(' ', chalk.gray(line))
+    })
+  }
 
   spinner.start()
 })


### PR DESCRIPTION
Thanks for writing this and esm-tape-runner. I use [zora](https://github.com/lorenzofox3/zora) as a TAP producing test library instead of tape.  Zora does not produce a stack trace when there is an error, so tap-monkey crashes. Here's my fix. I tested the pack file on my project. I also used rollup to create a CommonJS version of the project and tested with tape as the test runner. The tests were still zora, except one I converted to tape.

BTW, I've since found that pta is also an ES and CommonJS test runner that meets your requirements. Pta is the npm package name.